### PR TITLE
feat: add css to tailwind tool

### DIFF
--- a/src/app/css-to-tailwind/CssToTailwindForm.tsx
+++ b/src/app/css-to-tailwind/CssToTailwindForm.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { cssToTailwind } from "./css-to-tailwind";
+
+export const CssToTailwindForm = () => {
+  const [css, setCss] = useState("");
+  const [classes, setClasses] = useState<string[]>([]);
+
+  useEffect(() => {
+    setClasses(cssToTailwind(css));
+  }, [css]);
+
+  return (
+    <div>
+      <span className="text-sm opacity-70 block mb-2">Enter CSS</span>
+      <textarea
+        className="border border-neutral-600 p-2 rounded w-full text-neutral-300 h-40 font-mono"
+        placeholder={".selector {\n  display: flex;\n}"}
+        value={css}
+        onChange={(e) => setCss(e.target.value)}
+      />
+      {classes.length > 0 && (
+        <div className="mt-4">
+          <span className="text-sm opacity-70 block mb-2">Tailwind classes</span>
+          <div className="bg-neutral-800 p-2 rounded break-all">
+            {classes.join(" ")}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/app/css-to-tailwind/css-to-tailwind.test.ts
+++ b/src/app/css-to-tailwind/css-to-tailwind.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "vitest";
+import { cssToTailwind } from "./css-to-tailwind";
+
+describe("cssToTailwind", () => {
+  test("converts flex layout rules", () => {
+    const css = `.box { display: flex; justify-content: center; align-items: center; }`;
+    expect(cssToTailwind(css)).toEqual([
+      "flex",
+      "justify-center",
+      "items-center",
+    ]);
+  });
+
+  test("converts colors and font weight", () => {
+    const css = `h1 { color: red; font-weight: 700; }`;
+    expect(cssToTailwind(css)).toEqual(["text-red-500", "font-bold"]);
+  });
+
+  test("converts spacing properties", () => {
+    const css = `.padded { margin-top: 1rem; padding: 0.5rem; }`;
+    expect(cssToTailwind(css)).toEqual(["mt-4", "p-2"]);
+  });
+});

--- a/src/app/css-to-tailwind/css-to-tailwind.ts
+++ b/src/app/css-to-tailwind/css-to-tailwind.ts
@@ -1,0 +1,121 @@
+export const cssToTailwind = (css: string) => {
+  const regex = /([\w-]+)\s*:\s*([^;]+);?/g;
+  const classes: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(css)) !== null) {
+    const property = match[1].trim().toLowerCase();
+    const value = match[2].trim().toLowerCase();
+    const className = mapPropertyToClass(property, value);
+    if (className) {
+      classes.push(className);
+    }
+  }
+  return classes;
+};
+
+const mapPropertyToClass = (property: string, value: string) => {
+  const direct = propertyValueMap[property]?.[value];
+  if (direct) {
+    return direct;
+  }
+
+  if (spacingProperties[property]) {
+    const prefix = spacingProperties[property];
+    const scale = spacingScale[value];
+    if (scale) {
+      return `${prefix}-${scale}`;
+    }
+  }
+
+  if (colorProperties[property]) {
+    const prefix = colorProperties[property];
+    const color = colorMap[value];
+    if (color) {
+      return `${prefix}-${color}`;
+    }
+  }
+
+  return null;
+};
+
+const propertyValueMap: Record<string, Record<string, string>> = {
+  display: {
+    flex: "flex",
+    block: "block",
+    "inline-block": "inline-block",
+  },
+  "flex-direction": {
+    column: "flex-col",
+    row: "flex-row",
+  },
+  "justify-content": {
+    center: "justify-center",
+    "flex-start": "justify-start",
+    "flex-end": "justify-end",
+    "space-between": "justify-between",
+    "space-around": "justify-around",
+  },
+  "align-items": {
+    center: "items-center",
+    "flex-start": "items-start",
+    "flex-end": "items-end",
+    stretch: "items-stretch",
+    baseline: "items-baseline",
+  },
+  "text-align": {
+    center: "text-center",
+    left: "text-left",
+    right: "text-right",
+    justify: "text-justify",
+  },
+  "font-weight": {
+    "400": "font-normal",
+    normal: "font-normal",
+    "500": "font-medium",
+    medium: "font-medium",
+    "600": "font-semibold",
+    "700": "font-bold",
+    bold: "font-bold",
+  },
+};
+
+const spacingProperties: Record<string, string> = {
+  margin: "m",
+  "margin-top": "mt",
+  "margin-bottom": "mb",
+  "margin-left": "ml",
+  "margin-right": "mr",
+  padding: "p",
+  "padding-top": "pt",
+  "padding-bottom": "pb",
+  "padding-left": "pl",
+  "padding-right": "pr",
+};
+
+const spacingScale: Record<string, string> = {
+  "0": "0",
+  "0px": "0",
+  "4px": "1",
+  "0.25rem": "1",
+  "8px": "2",
+  "0.5rem": "2",
+  "16px": "4",
+  "1rem": "4",
+  "24px": "6",
+  "1.5rem": "6",
+  "32px": "8",
+  "2rem": "8",
+};
+
+const colorProperties: Record<string, string> = {
+  color: "text",
+  "background-color": "bg",
+};
+
+const colorMap: Record<string, string> = {
+  red: "red-500",
+  blue: "blue-500",
+  green: "green-500",
+  black: "black",
+  white: "white",
+};

--- a/src/app/css-to-tailwind/page.tsx
+++ b/src/app/css-to-tailwind/page.tsx
@@ -1,0 +1,18 @@
+import { Metadata } from "next";
+import { CssToTailwindForm } from "./CssToTailwindForm";
+
+export default function Page() {
+  return (
+    <div className="flex items-center justify-center flex-1">
+      <div className="w-md p-4 border border-neutral-700 bg-neutral-900 rounded-lg">
+        <h1 className="text-xl font-bold mb-4">CSS to Tailwind</h1>
+        <CssToTailwindForm />
+      </div>
+    </div>
+  );
+}
+
+export const metadata: Metadata = {
+  title: "CSS to Tailwind | Chris' Tools",
+  description: "Convert vanilla CSS rules to Tailwind classes.",
+};

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import { CardSim } from "lucide-react";
+import { CardSim, Palette } from "lucide-react";
 import { Metadata } from "next";
 import Link from "next/link";
 
@@ -6,13 +6,20 @@ export default function Home() {
   return (
     <div className="flex flex-1 flex-col items-center justify-center">
       <h1 className="text-2xl font-bold">🧰 Chris&apos; Tools</h1>
-      <div className="mt-4">
+      <div className="mt-4 flex flex-col gap-2">
         <Link
           href="/iccid-validator"
           className="flex items-center underline decoration-dashed"
         >
           <CardSim className="h-4 w-4 mr-2" />
           ICCID Validator
+        </Link>
+        <Link
+          href="/css-to-tailwind"
+          className="flex items-center underline decoration-dashed"
+        >
+          <Palette className="h-4 w-4 mr-2" />
+          CSS to Tailwind
         </Link>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add converter that maps basic CSS rules to Tailwind classes
- expose CSS to Tailwind form and page with static `/css-to-tailwind` route
- link new CSS to Tailwind tool from the homepage

## Testing
- `pnpm lint`
- `pnpm vitest run`


------
https://chatgpt.com/codex/tasks/task_e_689844b0d3608330839918f659f7e096