### PR TITLE
Add fluid to grams converter tool

### DIFF
--- a/src/app/fluid-to-grams/FluidToGramsForm.tsx
+++ b/src/app/fluid-to-grams/FluidToGramsForm.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  FLUID_DENSITIES,
+  FluidType,
+  VolumeUnit,
+  convertFluidToGrams,
+} from "./fluid-to-grams";
+
+export function FluidToGramsForm() {
+  const [volume, setVolume] = useState("1");
+  const [unit, setUnit] = useState<VolumeUnit>("ml");
+  const [fluid, setFluid] = useState<FluidType>("water");
+
+  const grams = useMemo(() => {
+    const parsedVolume = Number.parseFloat(volume);
+
+    if (!Number.isFinite(parsedVolume)) {
+      return null;
+    }
+
+    try {
+      return convertFluidToGrams(parsedVolume, unit, fluid);
+    } catch (error) {
+      console.error(error);
+      return null;
+    }
+  }, [volume, unit, fluid]);
+
+  const density = FLUID_DENSITIES[fluid];
+
+  return (
+    <form className="space-y-4">
+      <div>
+        <label className="mb-1 block text-sm font-medium" htmlFor="volume">
+          Volume
+        </label>
+        <div className="flex gap-2">
+          <input
+            id="volume"
+            name="volume"
+            type="number"
+            min="0"
+            step="any"
+            inputMode="decimal"
+            value={volume}
+            onChange={(event) => setVolume(event.target.value)}
+            className="flex-1 rounded-md border border-neutral-700 bg-neutral-950 px-3 py-2 text-sm focus:border-neutral-500 focus:outline-none"
+            aria-describedby="volume-helper"
+          />
+          <select
+            aria-label="Unit"
+            value={unit}
+            onChange={(event) => setUnit(event.target.value as VolumeUnit)}
+            className="rounded-md border border-neutral-700 bg-neutral-950 px-3 py-2 text-sm focus:border-neutral-500 focus:outline-none"
+          >
+            <option value="ml">milliliters (ml)</option>
+            <option value="l">liters (l)</option>
+          </select>
+        </div>
+        <p id="volume-helper" className="mt-1 text-xs text-neutral-400">
+          Density is applied per milliliter. Liters are converted automatically.
+        </p>
+      </div>
+
+      <div>
+        <label className="mb-1 block text-sm font-medium" htmlFor="fluid">
+          Fluid
+        </label>
+        <select
+          id="fluid"
+          name="fluid"
+          value={fluid}
+          onChange={(event) => setFluid(event.target.value as FluidType)}
+          className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-3 py-2 text-sm focus:border-neutral-500 focus:outline-none"
+        >
+          <option value="water">Water (1.00 g/ml)</option>
+          <option value="oil">Oil (0.92 g/ml)</option>
+        </select>
+      </div>
+
+      <div className="rounded-md border border-neutral-700 bg-neutral-950 px-3 py-3">
+        <h2 className="text-sm font-semibold">Result</h2>
+        {grams === null ? (
+          <p className="text-sm text-neutral-400">Enter a valid volume to convert.</p>
+        ) : (
+          <div className="mt-2 space-y-1 text-sm">
+            <p>
+              <span className="font-medium">Mass:</span> {grams} g
+            </p>
+            <p className="text-neutral-400">
+              Density used: {density.toFixed(2)} g/ml.
+            </p>
+          </div>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/src/app/fluid-to-grams/fluid-to-grams.test.ts
+++ b/src/app/fluid-to-grams/fluid-to-grams.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "vitest";
+import {
+  FLUID_DENSITIES,
+  convertFluidToGrams,
+  convertVolumeToMilliliters,
+} from "./fluid-to-grams";
+
+describe("convertVolumeToMilliliters", () => {
+  test("returns the same value for milliliters", () => {
+    expect(convertVolumeToMilliliters(250, "ml")).toBe(250);
+  });
+
+  test("converts liters to milliliters", () => {
+    expect(convertVolumeToMilliliters(1.5, "l")).toBe(1500);
+  });
+});
+
+describe("convertFluidToGrams", () => {
+  test("converts water correctly", () => {
+    expect(convertFluidToGrams(100, "ml", "water")).toBe(100);
+  });
+
+  test("converts oil correctly", () => {
+    const grams = convertFluidToGrams(2, "l", "oil");
+    expect(grams).toBeCloseTo(1840);
+  });
+
+  test("rounds to two decimal places", () => {
+    const grams = convertFluidToGrams(1, "ml", "oil");
+    expect(grams).toBe(Number((1 * FLUID_DENSITIES.oil).toFixed(2)));
+  });
+});

--- a/src/app/fluid-to-grams/fluid-to-grams.ts
+++ b/src/app/fluid-to-grams/fluid-to-grams.ts
@@ -1,0 +1,36 @@
+export const FLUID_DENSITIES = {
+  water: 1,
+  oil: 0.92,
+} as const;
+
+export type FluidType = keyof typeof FLUID_DENSITIES;
+
+export type VolumeUnit = "ml" | "l";
+
+export function convertVolumeToMilliliters(volume: number, unit: VolumeUnit) {
+  if (!Number.isFinite(volume)) {
+    throw new Error("Volume must be a finite number");
+  }
+
+  switch (unit) {
+    case "ml":
+      return volume;
+    case "l":
+      return volume * 1000;
+    default: {
+      const _exhaustiveCheck: never = unit;
+      throw new Error(`Unsupported unit: ${_exhaustiveCheck}`);
+    }
+  }
+}
+
+export function convertFluidToGrams(
+  volume: number,
+  unit: VolumeUnit,
+  fluid: FluidType,
+) {
+  const volumeInMilliliters = convertVolumeToMilliliters(volume, unit);
+  const density = FLUID_DENSITIES[fluid];
+
+  return Number((volumeInMilliliters * density).toFixed(2));
+}

--- a/src/app/fluid-to-grams/page.tsx
+++ b/src/app/fluid-to-grams/page.tsx
@@ -1,0 +1,25 @@
+import { Metadata } from "next";
+import { FluidToGramsForm } from "./FluidToGramsForm";
+
+export default function Page() {
+  return (
+    <div className="flex flex-1 items-center justify-center">
+      <div className="w-md space-y-4 rounded-lg border border-neutral-700 bg-neutral-900 p-4">
+        <div>
+          <h1 className="text-xl font-bold">Fluid to Grams Converter</h1>
+          <p className="text-sm text-neutral-300">
+            Convert common kitchen liquids from milliliters or liters to grams using
+            their density.
+          </p>
+        </div>
+        <FluidToGramsForm />
+      </div>
+    </div>
+  );
+}
+
+export const metadata: Metadata = {
+  title: "Fluid to Grams Converter | Chris' Tools",
+  description:
+    "Convert water and oil volumes into grams based on their density.",
+};

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import { CardSim } from "lucide-react";
+import { CardSim, Droplet } from "lucide-react";
 import { Metadata } from "next";
 import Link from "next/link";
 
@@ -13,6 +13,15 @@ export default function Home() {
         >
           <CardSim className="h-4 w-4 mr-2" />
           ICCID Validator
+        </Link>
+      </div>
+      <div className="mt-2">
+        <Link
+          href="/fluid-to-grams"
+          className="flex items-center underline decoration-dashed"
+        >
+          <Droplet className="mr-2 h-4 w-4" />
+          Fluid to Grams Converter
         </Link>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add a fluid-to-grams converter with a form for common liquids
- implement reusable conversion helpers with unit tests for water and oil
- link the new tool from the homepage navigation

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68fe52382aa48330ab03272f947a1676