### PR TITLE
Add client-side image to ASCII tool

### DIFF
--- a/src/app/image-to-ascii/ImageToAsciiTool.tsx
+++ b/src/app/image-to-ascii/ImageToAsciiTool.tsx
@@ -1,47 +1,24 @@
 /* eslint-disable @next/next/no-img-element */
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
 const DEFAULT_WIDTH = 80;
-const DEFAULT_BUCKETS = 12;
-const DEFAULT_VERTICAL_SCALE = 0.55;
-const DEFAULT_FONT_SIZE = 10;
+const DEFAULT_BUCKETS = 18;
+const DEFAULT_VERTICAL_SCALE = 0.75;
+const OUTPUT_FONT_SIZE = 9;
+const OUTPUT_LINE_HEIGHT = 0.68;
 
-const ASCII_GRADIENTS = [
-  {
-    id: "light-bg",
-    label: "Light background (subject darker)",
-    value: " .:-=+*#%@",
-  },
-  {
-    id: "light-bg-fine",
-    label: "Light background (fine detail)",
-    value:
-      " .'`^\",:;Il!i><~+_-?][}{1)(|\\/tfjrxnuvczXYUJCLQ0OZmwqpdbkhao*#MW&8%B@$",
-  },
-  {
-    id: "dark-bg",
-    label: "Dark background (subject lighter)",
-    value: "@%#*+=-:. ",
-  },
-  {
-    id: "dark-bg-fine",
-    label: "Dark background (fine detail)",
-    value:
-      "@$B%8&WM#*okdbpqmwZO0QLCJUYXzcvunxrjft/\\|)(1}{][?-_+~<>i!lI;:,\"^`'. ",
-  },
-  {
-    id: "blocky",
-    label: "Blocky",
-    value: "█▓▒░ ",
-  },
-];
+const BASE_ASCII_GRADIENT =
+  " .'`\",:;Il!i><~+_-?][}{1)(|\\/tfjrxnuvczXYUJCLQ0OZmwqpdbkhao*#MW&8%B@$";
+const REVERSED_ASCII_GRADIENT = BASE_ASCII_GRADIENT.split("").reverse().join("");
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
 
 const buildAsciiArt = (
   image: HTMLImageElement,
   width: number,
-  gradient: string,
   buckets: number,
   verticalScale: number,
 ) => {
@@ -61,7 +38,9 @@ const buildAsciiArt = (
   const imageData = context.getImageData(0, 0, width, height);
   const { data } = imageData;
 
-  let ascii = "";
+  const pixelCount = width * height;
+  const brightnessValues = new Float32Array(pixelCount);
+  let totalBrightness = 0;
 
   for (let y = 0; y < height; y += 1) {
     for (let x = 0; x < width; x += 1) {
@@ -71,12 +50,28 @@ const buildAsciiArt = (
       const b = data[offset + 2];
 
       const brightness = 0.299 * r + 0.587 * g + 0.114 * b;
-      const bucketSize = 255 / Math.max(1, buckets - 1);
+      const pixelIndex = y * width + x;
+      brightnessValues[pixelIndex] = brightness;
+      totalBrightness += brightness;
+    }
+  }
+
+  const averageBrightness = totalBrightness / pixelCount;
+  const gradient = averageBrightness > 127 ? BASE_ASCII_GRADIENT : REVERSED_ASCII_GRADIENT;
+  const bucketSize = 255 / Math.max(1, buckets - 1);
+  let ascii = "";
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const brightness = brightnessValues[y * width + x];
       const smoothedBrightness = Math.round(brightness / bucketSize) * bucketSize;
       const gradientIndex = Math.floor(
         ((gradient.length - 1) * (255 - smoothedBrightness)) / 255,
       );
-      ascii += gradient[gradientIndex];
+      const safeIndex = Number.isFinite(gradientIndex)
+        ? clamp(gradientIndex, 0, gradient.length - 1)
+        : 0;
+      ascii += gradient.charAt(safeIndex) || " ";
     }
     ascii += "\n";
   }
@@ -89,18 +84,9 @@ export const ImageToAsciiTool = () => {
   const [asciiArt, setAsciiArt] = useState("");
   const [width, setWidth] = useState(DEFAULT_WIDTH);
   const [error, setError] = useState<string | null>(null);
-  const [selectedGradientId, setSelectedGradientId] = useState(ASCII_GRADIENTS[0].id);
-  const [brightnessBuckets, setBrightnessBuckets] = useState(DEFAULT_BUCKETS);
-  const [verticalScale, setVerticalScale] = useState(DEFAULT_VERTICAL_SCALE);
-  const [fontSize, setFontSize] = useState(DEFAULT_FONT_SIZE);
-
-  const gradient = useMemo(
-    () => ASCII_GRADIENTS.find((option) => option.id === selectedGradientId)?.value,
-    [selectedGradientId],
-  );
 
   useEffect(() => {
-    if (!imageDataUrl || !gradient) {
+    if (!imageDataUrl) {
       setAsciiArt("");
       setError(null);
       return undefined;
@@ -115,13 +101,7 @@ export const ImageToAsciiTool = () => {
       }
 
       try {
-        const art = buildAsciiArt(
-          image,
-          width,
-          gradient,
-          brightnessBuckets,
-          verticalScale,
-        );
+        const art = buildAsciiArt(image, width, DEFAULT_BUCKETS, DEFAULT_VERTICAL_SCALE);
         setAsciiArt(art);
         setError(null);
       } catch (conversionError) {
@@ -144,7 +124,7 @@ export const ImageToAsciiTool = () => {
     return () => {
       cancelled = true;
     };
-  }, [brightnessBuckets, gradient, imageDataUrl, verticalScale, width]);
+  }, [imageDataUrl, width]);
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -166,34 +146,6 @@ export const ImageToAsciiTool = () => {
       return;
     }
     setWidth(Math.min(200, Math.max(20, value)));
-  };
-
-  const handleGradientChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    setSelectedGradientId(event.target.value);
-  };
-
-  const handleBucketsChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = Number(event.target.value);
-    if (Number.isNaN(value)) {
-      return;
-    }
-    setBrightnessBuckets(Math.min(32, Math.max(2, value)));
-  };
-
-  const handleVerticalScaleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = Number(event.target.value);
-    if (Number.isNaN(value)) {
-      return;
-    }
-    setVerticalScale(Number(value));
-  };
-
-  const handleFontSizeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = Number(event.target.value);
-    if (Number.isNaN(value)) {
-      return;
-    }
-    setFontSize(Math.min(16, Math.max(8, value)));
   };
 
   return (
@@ -223,70 +175,6 @@ export const ImageToAsciiTool = () => {
         />
       </div>
 
-      <div>
-        <label className="text-sm opacity-70 block mb-2" htmlFor="ascii-gradient">
-          Character style
-        </label>
-        <select
-          id="ascii-gradient"
-          value={selectedGradientId}
-          onChange={handleGradientChange}
-          className="w-full rounded border border-neutral-800 bg-neutral-900 px-3 py-2 text-sm"
-        >
-          {ASCII_GRADIENTS.map((option) => (
-            <option key={option.id} value={option.id}>
-              {option.label}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      <div>
-        <label className="text-sm opacity-70 block mb-2" htmlFor="ascii-buckets">
-          Tone smoothing ({brightnessBuckets} levels)
-        </label>
-        <input
-          id="ascii-buckets"
-          type="range"
-          min={2}
-          max={32}
-          value={brightnessBuckets}
-          onChange={handleBucketsChange}
-          className="w-full"
-        />
-      </div>
-
-      <div>
-        <label className="text-sm opacity-70 block mb-2" htmlFor="ascii-rows">
-          Row density ({verticalScale.toFixed(2)}x)
-        </label>
-        <input
-          id="ascii-rows"
-          type="range"
-          min={0.3}
-          max={1}
-          step={0.05}
-          value={verticalScale}
-          onChange={handleVerticalScaleChange}
-          className="w-full"
-        />
-      </div>
-
-      <div>
-        <label className="text-sm opacity-70 block mb-2" htmlFor="ascii-font-size">
-          Font size ({fontSize}px)
-        </label>
-        <input
-          id="ascii-font-size"
-          type="range"
-          min={8}
-          max={16}
-          value={fontSize}
-          onChange={handleFontSizeChange}
-          className="w-full"
-        />
-      </div>
-
       {error && <p className="text-red-500 text-sm">{error}</p>}
 
       {imageDataUrl && (
@@ -304,7 +192,10 @@ export const ImageToAsciiTool = () => {
         <span className="text-sm opacity-70 block mb-2">ASCII output</span>
         <pre
           className="bg-black/40 p-4 rounded overflow-auto whitespace-pre text-green-400 border border-neutral-800 min-h-40"
-          style={{ fontSize: `${fontSize}px`, lineHeight: `${fontSize * 0.8}px` }}
+          style={{
+            fontSize: `${OUTPUT_FONT_SIZE}px`,
+            lineHeight: `${OUTPUT_FONT_SIZE * OUTPUT_LINE_HEIGHT}px`,
+          }}
         >
           {asciiArt || "Upload an image to generate ASCII art."}
         </pre>

--- a/src/app/image-to-ascii/ImageToAsciiTool.tsx
+++ b/src/app/image-to-ascii/ImageToAsciiTool.tsx
@@ -5,6 +5,8 @@ import { useEffect, useMemo, useState } from "react";
 
 const DEFAULT_WIDTH = 80;
 const DEFAULT_BUCKETS = 12;
+const DEFAULT_VERTICAL_SCALE = 0.55;
+const DEFAULT_FONT_SIZE = 10;
 
 const ASCII_GRADIENTS = [
   {
@@ -41,10 +43,11 @@ const buildAsciiArt = (
   width: number,
   gradient: string,
   buckets: number,
+  verticalScale: number,
 ) => {
   const canvas = document.createElement("canvas");
   const scale = width / image.width;
-  const height = Math.max(1, Math.round(image.height * scale * 0.55));
+  const height = Math.max(1, Math.round(image.height * scale * verticalScale));
 
   canvas.width = width;
   canvas.height = height;
@@ -88,6 +91,8 @@ export const ImageToAsciiTool = () => {
   const [error, setError] = useState<string | null>(null);
   const [selectedGradientId, setSelectedGradientId] = useState(ASCII_GRADIENTS[0].id);
   const [brightnessBuckets, setBrightnessBuckets] = useState(DEFAULT_BUCKETS);
+  const [verticalScale, setVerticalScale] = useState(DEFAULT_VERTICAL_SCALE);
+  const [fontSize, setFontSize] = useState(DEFAULT_FONT_SIZE);
 
   const gradient = useMemo(
     () => ASCII_GRADIENTS.find((option) => option.id === selectedGradientId)?.value,
@@ -110,7 +115,13 @@ export const ImageToAsciiTool = () => {
       }
 
       try {
-        const art = buildAsciiArt(image, width, gradient, brightnessBuckets);
+        const art = buildAsciiArt(
+          image,
+          width,
+          gradient,
+          brightnessBuckets,
+          verticalScale,
+        );
         setAsciiArt(art);
         setError(null);
       } catch (conversionError) {
@@ -133,7 +144,7 @@ export const ImageToAsciiTool = () => {
     return () => {
       cancelled = true;
     };
-  }, [brightnessBuckets, gradient, imageDataUrl, width]);
+  }, [brightnessBuckets, gradient, imageDataUrl, verticalScale, width]);
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -167,6 +178,22 @@ export const ImageToAsciiTool = () => {
       return;
     }
     setBrightnessBuckets(Math.min(32, Math.max(2, value)));
+  };
+
+  const handleVerticalScaleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = Number(event.target.value);
+    if (Number.isNaN(value)) {
+      return;
+    }
+    setVerticalScale(Number(value));
+  };
+
+  const handleFontSizeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = Number(event.target.value);
+    if (Number.isNaN(value)) {
+      return;
+    }
+    setFontSize(Math.min(16, Math.max(8, value)));
   };
 
   return (
@@ -229,6 +256,37 @@ export const ImageToAsciiTool = () => {
         />
       </div>
 
+      <div>
+        <label className="text-sm opacity-70 block mb-2" htmlFor="ascii-rows">
+          Row density ({verticalScale.toFixed(2)}x)
+        </label>
+        <input
+          id="ascii-rows"
+          type="range"
+          min={0.3}
+          max={1}
+          step={0.05}
+          value={verticalScale}
+          onChange={handleVerticalScaleChange}
+          className="w-full"
+        />
+      </div>
+
+      <div>
+        <label className="text-sm opacity-70 block mb-2" htmlFor="ascii-font-size">
+          Font size ({fontSize}px)
+        </label>
+        <input
+          id="ascii-font-size"
+          type="range"
+          min={8}
+          max={16}
+          value={fontSize}
+          onChange={handleFontSizeChange}
+          className="w-full"
+        />
+      </div>
+
       {error && <p className="text-red-500 text-sm">{error}</p>}
 
       {imageDataUrl && (
@@ -244,7 +302,10 @@ export const ImageToAsciiTool = () => {
 
       <div>
         <span className="text-sm opacity-70 block mb-2">ASCII output</span>
-        <pre className="bg-black/40 p-4 rounded overflow-auto text-xs leading-[0.8rem] whitespace-pre text-green-400 border border-neutral-800 min-h-40">
+        <pre
+          className="bg-black/40 p-4 rounded overflow-auto whitespace-pre text-green-400 border border-neutral-800 min-h-40"
+          style={{ fontSize: `${fontSize}px`, lineHeight: `${fontSize * 0.8}px` }}
+        >
           {asciiArt || "Upload an image to generate ASCII art."}
         </pre>
       </div>

--- a/src/app/image-to-ascii/ImageToAsciiTool.tsx
+++ b/src/app/image-to-ascii/ImageToAsciiTool.tsx
@@ -1,0 +1,170 @@
+/* eslint-disable @next/next/no-img-element */
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+const DEFAULT_WIDTH = 80;
+const ASCII_GRADIENT = "@%#*+=-:. ";
+
+const buildAsciiArt = (
+  image: HTMLImageElement,
+  width: number,
+  gradient: string,
+) => {
+  const canvas = document.createElement("canvas");
+  const scale = width / image.width;
+  const height = Math.max(1, Math.round(image.height * scale * 0.55));
+
+  canvas.width = width;
+  canvas.height = height;
+
+  const context = canvas.getContext("2d");
+  if (!context) {
+    throw new Error("Could not get canvas context");
+  }
+
+  context.drawImage(image, 0, 0, width, height);
+  const imageData = context.getImageData(0, 0, width, height);
+  const { data } = imageData;
+
+  let ascii = "";
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const offset = (y * width + x) * 4;
+      const r = data[offset];
+      const g = data[offset + 1];
+      const b = data[offset + 2];
+
+      const brightness = 0.299 * r + 0.587 * g + 0.114 * b;
+      const gradientIndex = Math.floor(
+        ((gradient.length - 1) * (255 - brightness)) / 255,
+      );
+      ascii += gradient[gradientIndex];
+    }
+    ascii += "\n";
+  }
+
+  return ascii;
+};
+
+export const ImageToAsciiTool = () => {
+  const [imageDataUrl, setImageDataUrl] = useState<string | null>(null);
+  const [asciiArt, setAsciiArt] = useState("");
+  const [width, setWidth] = useState(DEFAULT_WIDTH);
+  const [error, setError] = useState<string | null>(null);
+
+  const gradient = useMemo(() => ASCII_GRADIENT, []);
+
+  useEffect(() => {
+    if (!imageDataUrl) {
+      setAsciiArt("");
+      setError(null);
+      return undefined;
+    }
+
+    let cancelled = false;
+    const image = new Image();
+
+    image.onload = () => {
+      if (cancelled) {
+        return;
+      }
+
+      try {
+        const art = buildAsciiArt(image, width, gradient);
+        setAsciiArt(art);
+        setError(null);
+      } catch (conversionError) {
+        setError(
+          conversionError instanceof Error
+            ? conversionError.message
+            : "Unable to convert image to ASCII.",
+        );
+      }
+    };
+
+    image.onerror = () => {
+      if (!cancelled) {
+        setError("Could not load the selected image.");
+      }
+    };
+
+    image.src = imageDataUrl;
+
+    return () => {
+      cancelled = true;
+    };
+  }, [gradient, imageDataUrl, width]);
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      setImageDataUrl(null);
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      setImageDataUrl(reader.result as string);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleWidthChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = Number(event.target.value);
+    if (Number.isNaN(value)) {
+      return;
+    }
+    setWidth(Math.min(200, Math.max(20, value)));
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <span className="text-sm opacity-70 block mb-2">Upload image</span>
+        <input
+          type="file"
+          accept="image/*"
+          onChange={handleFileChange}
+          className="block w-full text-sm text-neutral-300 file:mr-4 file:rounded file:border-0 file:bg-neutral-800 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-neutral-100 hover:file:bg-neutral-700"
+        />
+      </div>
+
+      <div>
+        <label className="text-sm opacity-70 block mb-2" htmlFor="ascii-width">
+          Output width ({width} characters)
+        </label>
+        <input
+          id="ascii-width"
+          type="range"
+          min={20}
+          max={200}
+          value={width}
+          onChange={handleWidthChange}
+          className="w-full"
+        />
+      </div>
+
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+
+      {imageDataUrl && (
+        <div>
+          <span className="text-sm opacity-70 block mb-2">Preview</span>
+          <img
+            src={imageDataUrl}
+            alt="Uploaded preview"
+            className="max-h-48 rounded border border-neutral-800"
+          />
+        </div>
+      )}
+
+      <div>
+        <span className="text-sm opacity-70 block mb-2">ASCII output</span>
+        <pre className="bg-black/40 p-4 rounded overflow-auto text-xs leading-[0.8rem] whitespace-pre text-green-400 border border-neutral-800 min-h-40">
+          {asciiArt || "Upload an image to generate ASCII art."}
+        </pre>
+      </div>
+    </div>
+  );
+};

--- a/src/app/image-to-ascii/ImageToAsciiTool.tsx
+++ b/src/app/image-to-ascii/ImageToAsciiTool.tsx
@@ -146,49 +146,49 @@ export const ImageToAsciiTool = () => {
   };
 
   return (
-    <div className="space-y-4">
-      <div>
-        <span className="text-sm opacity-70 block mb-2">Upload image</span>
-        <input
-          type="file"
-          accept="image/*"
-          onChange={handleFileChange}
-          className="block w-full text-sm text-neutral-300 file:mr-4 file:rounded file:border-0 file:bg-neutral-800 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-neutral-100 hover:file:bg-neutral-700"
-        />
-      </div>
-
-      {error && <p className="text-red-500 text-sm">{error}</p>}
-
-      {imageDataUrl && (
+    <div className="grid gap-6 lg:grid-cols-[320px,1fr]">
+      <div className="space-y-4">
         <div>
-          <span className="text-sm opacity-70 block mb-2">Preview</span>
-          <img
-            src={imageDataUrl}
-            alt="Uploaded preview"
-            className="max-h-48 rounded border border-neutral-800"
+          <span className="text-sm opacity-70 block mb-2">Upload image</span>
+          <input
+            type="file"
+            accept="image/*"
+            onChange={handleFileChange}
+            className="block w-full text-sm text-neutral-300 file:mr-4 file:rounded file:border-0 file:bg-neutral-800 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-neutral-100 hover:file:bg-neutral-700"
           />
         </div>
-      )}
 
-      <div>
-        <span className="text-sm opacity-70 block mb-2">ASCII output</span>
-        <div className="space-y-2">
-          <div className="text-xs text-neutral-400">
-            {outputWidth
-              ? `Rendered at ${outputWidth} columns for maximum detail.`
-              : "Upload to see a high-resolution ASCII render."}
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+
+        {imageDataUrl && (
+          <div>
+            <span className="text-sm opacity-70 block mb-2">Preview</span>
+            <img
+              src={imageDataUrl}
+              alt="Uploaded preview"
+              className="max-h-36 rounded border border-neutral-800 object-contain"
+            />
           </div>
-          <pre
-            className="bg-black/40 p-4 rounded overflow-auto whitespace-pre text-green-400 border border-neutral-800 min-h-40"
-            style={{
-              fontSize: `${OUTPUT_FONT_SIZE}px`,
-              lineHeight: `${OUTPUT_FONT_SIZE * OUTPUT_LINE_HEIGHT}px`,
-              letterSpacing: "0.4px",
-            }}
-          >
-            {asciiArt || "Upload an image to generate ASCII art."}
-          </pre>
+        )}
+      </div>
+
+      <div className="flex flex-col space-y-2">
+        <span className="text-sm opacity-70 block">ASCII output</span>
+        <div className="text-xs text-neutral-400">
+          {outputWidth
+            ? `Rendered at ${outputWidth} columns for maximum detail.`
+            : "Upload to see a high-resolution ASCII render."}
         </div>
+        <pre
+          className="flex-1 bg-black p-4 rounded overflow-auto whitespace-pre text-neutral-100 border border-neutral-800 min-h-[22rem]"
+          style={{
+            fontSize: `${OUTPUT_FONT_SIZE}px`,
+            lineHeight: `${OUTPUT_FONT_SIZE * OUTPUT_LINE_HEIGHT}px`,
+            letterSpacing: "0.4px",
+          }}
+        >
+          {asciiArt || "Upload an image to generate ASCII art."}
+        </pre>
       </div>
     </div>
   );

--- a/src/app/image-to-ascii/ImageToAsciiTool.tsx
+++ b/src/app/image-to-ascii/ImageToAsciiTool.tsx
@@ -4,14 +4,31 @@
 import { useEffect, useMemo, useState } from "react";
 
 const DEFAULT_WIDTH = 80;
-const ASCII_GRADIENT = "@%#*+=-:. ";
+const DEFAULT_BUCKETS = 12;
 
-const BRIGHTNESS_BUCKETS = 12;
+const ASCII_GRADIENTS = [
+  {
+    id: "light-bg",
+    label: "Light background (subject darker)",
+    value: " .:-=+*#%@",
+  },
+  {
+    id: "dark-bg",
+    label: "Dark background (subject lighter)",
+    value: "@%#*+=-:. ",
+  },
+  {
+    id: "blocky",
+    label: "Blocky",
+    value: "█▓▒░ ",
+  },
+];
 
 const buildAsciiArt = (
   image: HTMLImageElement,
   width: number,
   gradient: string,
+  buckets: number,
 ) => {
   const canvas = document.createElement("canvas");
   const scale = width / image.width;
@@ -39,7 +56,7 @@ const buildAsciiArt = (
       const b = data[offset + 2];
 
       const brightness = 0.299 * r + 0.587 * g + 0.114 * b;
-      const bucketSize = 255 / (BRIGHTNESS_BUCKETS - 1);
+      const bucketSize = 255 / Math.max(1, buckets - 1);
       const smoothedBrightness = Math.round(brightness / bucketSize) * bucketSize;
       const gradientIndex = Math.floor(
         ((gradient.length - 1) * (255 - smoothedBrightness)) / 255,
@@ -57,11 +74,16 @@ export const ImageToAsciiTool = () => {
   const [asciiArt, setAsciiArt] = useState("");
   const [width, setWidth] = useState(DEFAULT_WIDTH);
   const [error, setError] = useState<string | null>(null);
+  const [selectedGradientId, setSelectedGradientId] = useState(ASCII_GRADIENTS[0].id);
+  const [brightnessBuckets, setBrightnessBuckets] = useState(DEFAULT_BUCKETS);
 
-  const gradient = useMemo(() => ASCII_GRADIENT, []);
+  const gradient = useMemo(
+    () => ASCII_GRADIENTS.find((option) => option.id === selectedGradientId)?.value,
+    [selectedGradientId],
+  );
 
   useEffect(() => {
-    if (!imageDataUrl) {
+    if (!imageDataUrl || !gradient) {
       setAsciiArt("");
       setError(null);
       return undefined;
@@ -76,7 +98,7 @@ export const ImageToAsciiTool = () => {
       }
 
       try {
-        const art = buildAsciiArt(image, width, gradient);
+        const art = buildAsciiArt(image, width, gradient, brightnessBuckets);
         setAsciiArt(art);
         setError(null);
       } catch (conversionError) {
@@ -99,7 +121,7 @@ export const ImageToAsciiTool = () => {
     return () => {
       cancelled = true;
     };
-  }, [gradient, imageDataUrl, width]);
+  }, [brightnessBuckets, gradient, imageDataUrl, width]);
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -121,6 +143,18 @@ export const ImageToAsciiTool = () => {
       return;
     }
     setWidth(Math.min(200, Math.max(20, value)));
+  };
+
+  const handleGradientChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    setSelectedGradientId(event.target.value);
+  };
+
+  const handleBucketsChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = Number(event.target.value);
+    if (Number.isNaN(value)) {
+      return;
+    }
+    setBrightnessBuckets(Math.min(32, Math.max(2, value)));
   };
 
   return (
@@ -146,6 +180,39 @@ export const ImageToAsciiTool = () => {
           max={200}
           value={width}
           onChange={handleWidthChange}
+          className="w-full"
+        />
+      </div>
+
+      <div>
+        <label className="text-sm opacity-70 block mb-2" htmlFor="ascii-gradient">
+          Character style
+        </label>
+        <select
+          id="ascii-gradient"
+          value={selectedGradientId}
+          onChange={handleGradientChange}
+          className="w-full rounded border border-neutral-800 bg-neutral-900 px-3 py-2 text-sm"
+        >
+          {ASCII_GRADIENTS.map((option) => (
+            <option key={option.id} value={option.id}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label className="text-sm opacity-70 block mb-2" htmlFor="ascii-buckets">
+          Tone smoothing ({brightnessBuckets} levels)
+        </label>
+        <input
+          id="ascii-buckets"
+          type="range"
+          min={2}
+          max={32}
+          value={brightnessBuckets}
+          onChange={handleBucketsChange}
           className="w-full"
         />
       </div>

--- a/src/app/image-to-ascii/ImageToAsciiTool.tsx
+++ b/src/app/image-to-ascii/ImageToAsciiTool.tsx
@@ -6,6 +6,8 @@ import { useEffect, useMemo, useState } from "react";
 const DEFAULT_WIDTH = 80;
 const ASCII_GRADIENT = "@%#*+=-:. ";
 
+const BRIGHTNESS_BUCKETS = 12;
+
 const buildAsciiArt = (
   image: HTMLImageElement,
   width: number,
@@ -37,8 +39,10 @@ const buildAsciiArt = (
       const b = data[offset + 2];
 
       const brightness = 0.299 * r + 0.587 * g + 0.114 * b;
+      const bucketSize = 255 / (BRIGHTNESS_BUCKETS - 1);
+      const smoothedBrightness = Math.round(brightness / bucketSize) * bucketSize;
       const gradientIndex = Math.floor(
-        ((gradient.length - 1) * (255 - brightness)) / 255,
+        ((gradient.length - 1) * (255 - smoothedBrightness)) / 255,
       );
       ascii += gradient[gradientIndex];
     }

--- a/src/app/image-to-ascii/ImageToAsciiTool.tsx
+++ b/src/app/image-to-ascii/ImageToAsciiTool.tsx
@@ -13,9 +13,21 @@ const ASCII_GRADIENTS = [
     value: " .:-=+*#%@",
   },
   {
+    id: "light-bg-fine",
+    label: "Light background (fine detail)",
+    value:
+      " .'`^\",:;Il!i><~+_-?][}{1)(|\\/tfjrxnuvczXYUJCLQ0OZmwqpdbkhao*#MW&8%B@$",
+  },
+  {
     id: "dark-bg",
     label: "Dark background (subject lighter)",
     value: "@%#*+=-:. ",
+  },
+  {
+    id: "dark-bg-fine",
+    label: "Dark background (fine detail)",
+    value:
+      "@$B%8&WM#*okdbpqmwZO0QLCJUYXzcvunxrjft/\\|)(1}{][?-_+~<>i!lI;:,\"^`'. ",
   },
   {
     id: "blocky",

--- a/src/app/image-to-ascii/ImageToAsciiTool.tsx
+++ b/src/app/image-to-ascii/ImageToAsciiTool.tsx
@@ -3,15 +3,16 @@
 
 import { useEffect, useState } from "react";
 
-const DEFAULT_WIDTH = 80;
-const DEFAULT_BUCKETS = 18;
-const DEFAULT_VERTICAL_SCALE = 0.75;
-const OUTPUT_FONT_SIZE = 9;
-const OUTPUT_LINE_HEIGHT = 0.68;
+const MIN_OUTPUT_WIDTH = 160;
+const MAX_OUTPUT_WIDTH = 240;
+const WIDTH_SCALE = 0.85;
+const DEFAULT_BUCKETS = 32;
+const DEFAULT_VERTICAL_SCALE = 1.1;
+const OUTPUT_FONT_SIZE = 7;
+const OUTPUT_LINE_HEIGHT = 0.58;
 
 const BASE_ASCII_GRADIENT =
   " .'`\",:;Il!i><~+_-?][}{1)(|\\/tfjrxnuvczXYUJCLQ0OZmwqpdbkhao*#MW&8%B@$";
-const REVERSED_ASCII_GRADIENT = BASE_ASCII_GRADIENT.split("").reverse().join("");
 
 const clamp = (value: number, min: number, max: number) =>
   Math.min(Math.max(value, min), max);
@@ -40,7 +41,6 @@ const buildAsciiArt = (
 
   const pixelCount = width * height;
   const brightnessValues = new Float32Array(pixelCount);
-  let totalBrightness = 0;
 
   for (let y = 0; y < height; y += 1) {
     for (let x = 0; x < width; x += 1) {
@@ -52,12 +52,10 @@ const buildAsciiArt = (
       const brightness = 0.299 * r + 0.587 * g + 0.114 * b;
       const pixelIndex = y * width + x;
       brightnessValues[pixelIndex] = brightness;
-      totalBrightness += brightness;
     }
   }
 
-  const averageBrightness = totalBrightness / pixelCount;
-  const gradient = averageBrightness > 127 ? BASE_ASCII_GRADIENT : REVERSED_ASCII_GRADIENT;
+  const gradient = BASE_ASCII_GRADIENT;
   const bucketSize = 255 / Math.max(1, buckets - 1);
   let ascii = "";
 
@@ -82,13 +80,14 @@ const buildAsciiArt = (
 export const ImageToAsciiTool = () => {
   const [imageDataUrl, setImageDataUrl] = useState<string | null>(null);
   const [asciiArt, setAsciiArt] = useState("");
-  const [width, setWidth] = useState(DEFAULT_WIDTH);
+  const [outputWidth, setOutputWidth] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!imageDataUrl) {
       setAsciiArt("");
       setError(null);
+      setOutputWidth(null);
       return undefined;
     }
 
@@ -101,8 +100,14 @@ export const ImageToAsciiTool = () => {
       }
 
       try {
-        const art = buildAsciiArt(image, width, DEFAULT_BUCKETS, DEFAULT_VERTICAL_SCALE);
+        const derivedWidth = clamp(
+          Math.round(image.width * WIDTH_SCALE),
+          MIN_OUTPUT_WIDTH,
+          MAX_OUTPUT_WIDTH,
+        );
+        const art = buildAsciiArt(image, derivedWidth, DEFAULT_BUCKETS, DEFAULT_VERTICAL_SCALE);
         setAsciiArt(art);
+        setOutputWidth(derivedWidth);
         setError(null);
       } catch (conversionError) {
         setError(
@@ -124,7 +129,7 @@ export const ImageToAsciiTool = () => {
     return () => {
       cancelled = true;
     };
-  }, [imageDataUrl, width]);
+  }, [imageDataUrl]);
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -140,14 +145,6 @@ export const ImageToAsciiTool = () => {
     reader.readAsDataURL(file);
   };
 
-  const handleWidthChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = Number(event.target.value);
-    if (Number.isNaN(value)) {
-      return;
-    }
-    setWidth(Math.min(200, Math.max(20, value)));
-  };
-
   return (
     <div className="space-y-4">
       <div>
@@ -157,21 +154,6 @@ export const ImageToAsciiTool = () => {
           accept="image/*"
           onChange={handleFileChange}
           className="block w-full text-sm text-neutral-300 file:mr-4 file:rounded file:border-0 file:bg-neutral-800 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-neutral-100 hover:file:bg-neutral-700"
-        />
-      </div>
-
-      <div>
-        <label className="text-sm opacity-70 block mb-2" htmlFor="ascii-width">
-          Output width ({width} characters)
-        </label>
-        <input
-          id="ascii-width"
-          type="range"
-          min={20}
-          max={200}
-          value={width}
-          onChange={handleWidthChange}
-          className="w-full"
         />
       </div>
 
@@ -190,15 +172,23 @@ export const ImageToAsciiTool = () => {
 
       <div>
         <span className="text-sm opacity-70 block mb-2">ASCII output</span>
-        <pre
-          className="bg-black/40 p-4 rounded overflow-auto whitespace-pre text-green-400 border border-neutral-800 min-h-40"
-          style={{
-            fontSize: `${OUTPUT_FONT_SIZE}px`,
-            lineHeight: `${OUTPUT_FONT_SIZE * OUTPUT_LINE_HEIGHT}px`,
-          }}
-        >
-          {asciiArt || "Upload an image to generate ASCII art."}
-        </pre>
+        <div className="space-y-2">
+          <div className="text-xs text-neutral-400">
+            {outputWidth
+              ? `Rendered at ${outputWidth} columns for maximum detail.`
+              : "Upload to see a high-resolution ASCII render."}
+          </div>
+          <pre
+            className="bg-black/40 p-4 rounded overflow-auto whitespace-pre text-green-400 border border-neutral-800 min-h-40"
+            style={{
+              fontSize: `${OUTPUT_FONT_SIZE}px`,
+              lineHeight: `${OUTPUT_FONT_SIZE * OUTPUT_LINE_HEIGHT}px`,
+              letterSpacing: "0.4px",
+            }}
+          >
+            {asciiArt || "Upload an image to generate ASCII art."}
+          </pre>
+        </div>
       </div>
     </div>
   );

--- a/src/app/image-to-ascii/page.tsx
+++ b/src/app/image-to-ascii/page.tsx
@@ -4,8 +4,8 @@ import { ImageToAsciiTool } from "./ImageToAsciiTool";
 export default function Page() {
   return (
     <div className="flex flex-1 items-center justify-center">
-      <div className="w-full max-w-2xl p-4 border border-neutral-700 bg-neutral-900 rounded-lg">
-        <h1 className="text-xl font-bold mb-4">Image to ASCII</h1>
+      <div className="w-full max-w-6xl p-6 border border-neutral-700 bg-neutral-900 rounded-lg">
+        <h1 className="text-xl font-bold mb-3">Image to ASCII</h1>
         <p className="text-sm text-neutral-400 mb-6">
           Upload an image and we&apos;ll convert it to ASCII art right in your
           browser.

--- a/src/app/image-to-ascii/page.tsx
+++ b/src/app/image-to-ascii/page.tsx
@@ -1,0 +1,22 @@
+import { Metadata } from "next";
+import { ImageToAsciiTool } from "./ImageToAsciiTool";
+
+export default function Page() {
+  return (
+    <div className="flex flex-1 items-center justify-center">
+      <div className="w-full max-w-2xl p-4 border border-neutral-700 bg-neutral-900 rounded-lg">
+        <h1 className="text-xl font-bold mb-4">Image to ASCII</h1>
+        <p className="text-sm text-neutral-400 mb-6">
+          Upload an image and we&apos;ll convert it to ASCII art right in your
+          browser.
+        </p>
+        <ImageToAsciiTool />
+      </div>
+    </div>
+  );
+}
+
+export const metadata: Metadata = {
+  title: "Image to ASCII | Chris' Tools",
+  description: "Convert any image to ASCII art directly in your browser.",
+};

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import { CardSim } from "lucide-react";
+import { CardSim, Image as ImageIcon } from "lucide-react";
 import { Metadata } from "next";
 import Link from "next/link";
 
@@ -6,13 +6,20 @@ export default function Home() {
   return (
     <div className="flex flex-1 flex-col items-center justify-center">
       <h1 className="text-2xl font-bold">🧰 Chris&apos; Tools</h1>
-      <div className="mt-4">
+      <div className="mt-4 space-y-2">
         <Link
           href="/iccid-validator"
           className="flex items-center underline decoration-dashed"
         >
           <CardSim className="h-4 w-4 mr-2" />
           ICCID Validator
+        </Link>
+        <Link
+          href="/image-to-ascii"
+          className="flex items-center underline decoration-dashed"
+        >
+          <ImageIcon className="h-4 w-4 mr-2" />
+          Image to ASCII
         </Link>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add a new Image to ASCII page with a client-side converter component
- link the new tool from the home page so it is discoverable

## Testing
- `pnpm lint`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a037e2a148330ab3d3f7c4a9069ee)