### PR TITLE
TOON formatter: auto-sync TOON/JSON and always-show readable output

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import { CardSim, Image as ImageIcon } from "lucide-react";
+import { CardSim, FileText, Image as ImageIcon } from "lucide-react";
 import { Metadata } from "next";
 import Link from "next/link";
 
@@ -20,6 +20,13 @@ export default function Home() {
         >
           <ImageIcon className="h-4 w-4 mr-2" />
           Image to ASCII
+        </Link>
+        <Link
+          href="/toon-tool"
+          className="flex items-center underline decoration-dashed"
+        >
+          <FileText className="h-4 w-4 mr-2" />
+          TOON Formatter
         </Link>
       </div>
     </div>

--- a/src/app/toon-tool/ToonTool.tsx
+++ b/src/app/toon-tool/ToonTool.tsx
@@ -74,7 +74,12 @@ const parseToon = (input: string): unknown => {
         continue;
       }
 
-      return { line: lines[i], trimmed, indent: countIndent(lines[i]) };
+      return {
+        line: lines[i],
+        trimmed,
+        indent: countIndent(lines[i]),
+        index: i,
+      };
     }
 
     return null;
@@ -161,14 +166,52 @@ const parseToon = (input: string): unknown => {
     const valuePart = match[2];
     if (!valuePart) {
       const nextLine = findNextMeaningfulLine(index);
-      const childIsArray = nextLine?.trimmed.startsWith("-") ?? false;
-      const child: ToonContainer = childIsArray ? [] : {};
-      (current.container as Record<string, unknown>)[key] = child;
-      stack.push({
-        indent,
-        container: child,
-        type: childIsArray ? "array" : "object",
-      });
+      const isIndentedValue =
+        nextLine &&
+        nextLine.indent > indent &&
+        !nextLine.trimmed.startsWith("-") &&
+        !nextLine.trimmed.includes(":");
+
+      if (isIndentedValue) {
+        const collected: string[] = [];
+        let cursor = nextLine.index;
+        while (cursor < lines.length) {
+          const candidate = lines[cursor];
+          const candidateTrimmed = candidate.trim();
+          if (!candidateTrimmed || COMMENT_RE.test(candidateTrimmed)) {
+            cursor += 1;
+            continue;
+          }
+
+          const candidateIndent = countIndent(candidate);
+          if (candidateIndent <= indent) {
+            break;
+          }
+
+          if (
+            candidateTrimmed.startsWith("-") ||
+            candidateTrimmed.includes(":")
+          ) {
+            break;
+          }
+
+          collected.push(candidateTrimmed);
+          cursor += 1;
+        }
+
+        (current.container as Record<string, unknown>)[key] =
+          collected.join("\n");
+        index = cursor - 1;
+      } else {
+        const childIsArray = nextLine?.trimmed.startsWith("-") ?? false;
+        const child: ToonContainer = childIsArray ? [] : {};
+        (current.container as Record<string, unknown>)[key] = child;
+        stack.push({
+          indent,
+          container: child,
+          type: childIsArray ? "array" : "object",
+        });
+      }
     } else {
       (current.container as Record<string, unknown>)[key] =
         parseScalar(valuePart);

--- a/src/app/toon-tool/ToonTool.tsx
+++ b/src/app/toon-tool/ToonTool.tsx
@@ -1,0 +1,356 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type ToonContainer = Record<string, unknown> | unknown[];
+
+const COMMENT_RE = /^\s*(#|\/\/)/;
+
+const countIndent = (line: string) => line.match(/^\s*/)?.[0].length ?? 0;
+
+const isScalarValue = (value: unknown) =>
+  typeof value !== "object" || value === null;
+
+const parseScalar = (rawValue: string): unknown => {
+  if (rawValue === "") {
+    return "";
+  }
+
+  const trimmed = rawValue.trim();
+  const quoted =
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"));
+
+  if (quoted) {
+    return trimmed
+      .slice(1, -1)
+      .replace(/\\(["'\\])/g, "$1")
+      .replace(/\\n/g, "\n");
+  }
+
+  if (/^-?\d+(\.\d+)?$/.test(trimmed)) {
+    return Number(trimmed);
+  }
+
+  if (trimmed === "true") {
+    return true;
+  }
+
+  if (trimmed === "false") {
+    return false;
+  }
+
+  if (trimmed === "null") {
+    return null;
+  }
+
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    const inner = trimmed.slice(1, -1).trim();
+    if (!inner) {
+      return [];
+    }
+
+    return inner.split(",").map((item) => parseScalar(item.trim()));
+  }
+
+  if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      return trimmed;
+    }
+  }
+
+  return trimmed;
+};
+
+const parseToon = (input: string): unknown => {
+  const lines = input.replace(/\t/g, "  ").split(/\r?\n/);
+
+  const findNextMeaningfulLine = (startIndex: number) => {
+    for (let i = startIndex + 1; i < lines.length; i += 1) {
+      const trimmed = lines[i].trim();
+      if (!trimmed || COMMENT_RE.test(trimmed)) {
+        continue;
+      }
+
+      return { line: lines[i], trimmed, indent: countIndent(lines[i]) };
+    }
+
+    return null;
+  };
+
+  const firstMeaningfulLine = findNextMeaningfulLine(-1);
+  const rootIsArray = firstMeaningfulLine?.trimmed.startsWith("-") ?? false;
+  const root: ToonContainer = rootIsArray ? [] : {};
+
+  const stack: Array<{
+    indent: number;
+    container: ToonContainer;
+    type: "array" | "object";
+  }> = [{ indent: -1, container: root, type: rootIsArray ? "array" : "object" }];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const rawLine = lines[index];
+    const trimmed = rawLine.trim();
+
+    if (!trimmed || COMMENT_RE.test(trimmed)) {
+      continue;
+    }
+
+    const indent = countIndent(rawLine);
+    while (stack.length > 1 && indent <= stack[stack.length - 1].indent) {
+      stack.pop();
+    }
+
+    const current = stack[stack.length - 1];
+
+    if (trimmed.startsWith("-")) {
+      if (current.type !== "array") {
+        throw new Error(
+          "Found an array item where an object entry was expected.",
+        );
+      }
+
+      const rest = trimmed.slice(1).trim();
+      if (!rest) {
+        const nextLine = findNextMeaningfulLine(index);
+        const childIsArray = nextLine?.trimmed.startsWith("-") ?? false;
+        const child: ToonContainer = childIsArray ? [] : {};
+        (current.container as unknown[]).push(child);
+        stack.push({
+          indent,
+          container: child,
+          type: childIsArray ? "array" : "object",
+        });
+        continue;
+      }
+
+      const match = rest.match(/^([^:]+):\s*(.*)$/);
+      if (match) {
+        const key = match[1].trim();
+        const valuePart = match[2];
+        if (!valuePart) {
+          const nextLine = findNextMeaningfulLine(index);
+          const childIsArray = nextLine?.trimmed.startsWith("-") ?? false;
+          const child: ToonContainer = childIsArray ? [] : {};
+          (current.container as unknown[]).push({ [key]: child });
+          stack.push({
+            indent,
+            container: child,
+            type: childIsArray ? "array" : "object",
+          });
+        } else {
+          (current.container as unknown[]).push({
+            [key]: parseScalar(valuePart),
+          });
+        }
+      } else {
+        (current.container as unknown[]).push(parseScalar(rest));
+      }
+
+      continue;
+    }
+
+    const match = trimmed.match(/^([^:]+):\s*(.*)$/);
+    if (!match) {
+      throw new Error(`Unable to parse line: "${trimmed}"`);
+    }
+
+    const key = match[1].trim();
+    const valuePart = match[2];
+    if (!valuePart) {
+      const nextLine = findNextMeaningfulLine(index);
+      const childIsArray = nextLine?.trimmed.startsWith("-") ?? false;
+      const child: ToonContainer = childIsArray ? [] : {};
+      (current.container as Record<string, unknown>)[key] = child;
+      stack.push({
+        indent,
+        container: child,
+        type: childIsArray ? "array" : "object",
+      });
+    } else {
+      (current.container as Record<string, unknown>)[key] =
+        parseScalar(valuePart);
+    }
+  }
+
+  return root;
+};
+
+const formatScalarForToon = (value: unknown) => {
+  if (typeof value === "string") {
+    return JSON.stringify(value);
+  }
+
+  if (value === null) {
+    return "null";
+  }
+
+  return String(value);
+};
+
+const formatToon = (value: unknown, indent = 0): string => {
+  const prefix = " ".repeat(indent);
+
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => {
+        if (isScalarValue(item)) {
+          return `${prefix}- ${formatScalarForToon(item)}`;
+        }
+
+        const nested = formatToon(item, indent + 2);
+        return `${prefix}-\n${nested}`;
+      })
+      .join("\n");
+  }
+
+  if (typeof value === "object" && value !== null) {
+    return Object.entries(value)
+      .map(([key, entry]) => {
+        if (isScalarValue(entry)) {
+          return `${prefix}${key}: ${formatScalarForToon(entry)}`;
+        }
+
+        const nested = formatToon(entry, indent + 2);
+        return `${prefix}${key}:\n${nested}`;
+      })
+      .join("\n");
+  }
+
+  return `${prefix}${formatScalarForToon(value)}`;
+};
+
+const formatReadable = (value: unknown, indent = 0): string[] => {
+  const prefix = " ".repeat(indent);
+
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => {
+      if (isScalarValue(item)) {
+        return [`${prefix}• ${formatScalarForToon(item)}`];
+      }
+
+      return [
+        `${prefix}•`,
+        ...formatReadable(item, indent + 2),
+      ];
+    });
+  }
+
+  if (typeof value === "object" && value !== null) {
+    return Object.entries(value).flatMap(([key, entry]) => {
+      if (isScalarValue(entry)) {
+        return [`${prefix}• ${key}: ${formatScalarForToon(entry)}`];
+      }
+
+      return [
+        `${prefix}• ${key}:`,
+        ...formatReadable(entry, indent + 2),
+      ];
+    });
+  }
+
+  return [`${prefix}• ${formatScalarForToon(value)}`];
+};
+
+export const ToonTool = () => {
+  const [toonInput, setToonInput] = useState("");
+  const [jsonInput, setJsonInput] = useState("");
+  const [readableOutput, setReadableOutput] = useState("");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [lastEdited, setLastEdited] = useState<"toon" | "json" | null>(null);
+
+  useEffect(() => {
+    if (lastEdited !== "toon") {
+      return;
+    }
+
+    try {
+      const parsed = parseToon(toonInput);
+      const formattedJson = JSON.stringify(parsed, null, 2);
+      setJsonInput((previous) =>
+        previous === formattedJson ? previous : formattedJson,
+      );
+      setReadableOutput(formatReadable(parsed).join("\n"));
+      setErrorMessage(null);
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Unable to parse TOON input.",
+      );
+    }
+  }, [lastEdited, toonInput]);
+
+  useEffect(() => {
+    if (lastEdited !== "json") {
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(jsonInput);
+      const formattedToon = formatToon(parsed);
+      setToonInput((previous) =>
+        previous === formattedToon ? previous : formattedToon,
+      );
+      setReadableOutput(formatReadable(parsed).join("\n"));
+      setErrorMessage(null);
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Unable to parse JSON input.",
+      );
+    }
+  }, [jsonInput, lastEdited]);
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-neutral-400">
+        Changes sync automatically between TOON and JSON, and the readable
+        summary updates as you type.
+      </p>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <label className="flex flex-col gap-2">
+          <span className="text-sm text-neutral-400">TOON</span>
+          <textarea
+            className="min-h-[240px] rounded border border-neutral-700 bg-neutral-950 p-3 font-mono text-sm"
+            placeholder="Paste TOON input here."
+            value={toonInput}
+            onChange={(event) => {
+              setLastEdited("toon");
+              setToonInput(event.target.value);
+            }}
+          />
+        </label>
+
+        <label className="flex flex-col gap-2">
+          <span className="text-sm text-neutral-400">JSON</span>
+          <textarea
+            className="min-h-[240px] rounded border border-neutral-700 bg-neutral-950 p-3 font-mono text-sm"
+            placeholder="Paste JSON input here."
+            value={jsonInput}
+            onChange={(event) => {
+              setLastEdited("json");
+              setJsonInput(event.target.value);
+            }}
+          />
+        </label>
+
+        <label className="flex flex-col gap-2 md:col-span-2">
+          <span className="text-sm text-neutral-400">Readable TOON</span>
+          <textarea
+            className="min-h-[180px] rounded border border-neutral-700 bg-neutral-950 p-3 font-mono text-sm"
+            placeholder="Human readable output will appear here."
+            value={readableOutput}
+            readOnly
+          />
+        </label>
+      </div>
+
+      {errorMessage ? (
+        <div className="rounded border border-neutral-800 bg-neutral-950 p-3 text-xs text-neutral-400">
+          <p className="text-red-400">Error: {errorMessage}</p>
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/src/app/toon-tool/ToonTool.tsx
+++ b/src/app/toon-tool/ToonTool.tsx
@@ -64,6 +64,29 @@ const parseScalar = (rawValue: string): unknown => {
   return trimmed;
 };
 
+const parseCommaList = (valuePart: string) =>
+  valuePart
+    .split(",")
+    .map((entry) => parseScalar(entry.trim()))
+    .filter((entry) => entry !== "");
+
+const parseKeySpec = (rawKey: string) => {
+  const match = rawKey.match(
+    /^(?<name>[^\[\{]+)(?:\[(?<count>\d+)\])?(?:\{(?<fields>[^}]+)\})?$/,
+  );
+  if (!match || !match.groups) {
+    return null;
+  }
+
+  return {
+    name: match.groups.name.trim(),
+    count: match.groups.count ? Number(match.groups.count) : null,
+    fields: match.groups.fields
+      ? match.groups.fields.split(",").map((field) => field.trim())
+      : null,
+  };
+};
+
 const parseToon = (input: string): unknown => {
   const lines = input.replace(/\t/g, "  ").split(/\r?\n/);
 
@@ -162,8 +185,10 @@ const parseToon = (input: string): unknown => {
       throw new Error(`Unable to parse line: "${trimmed}"`);
     }
 
-    const key = match[1].trim();
+    const rawKey = match[1].trim();
     const valuePart = match[2];
+    const keySpec = parseKeySpec(rawKey);
+    const key = keySpec?.name ?? rawKey;
     if (!valuePart) {
       const nextLine = findNextMeaningfulLine(index);
       const isIndentedValue =
@@ -199,8 +224,30 @@ const parseToon = (input: string): unknown => {
           cursor += 1;
         }
 
-        (current.container as Record<string, unknown>)[key] =
-          collected.join("\n");
+        const joined = collected.join("\n");
+        if (keySpec?.fields?.length) {
+          const rows = collected
+            .map((row) =>
+              row
+                .split(",")
+                .map((entry) => parseScalar(entry.trim())),
+            )
+            .filter((row) => row.length > 0);
+          (current.container as Record<string, unknown>)[key] = rows.map(
+            (row) =>
+              Object.fromEntries(
+                keySpec.fields.map((field, fieldIndex) => [
+                  field,
+                  row[fieldIndex] ?? null,
+                ]),
+              ),
+          );
+        } else if (keySpec?.count) {
+          (current.container as Record<string, unknown>)[key] =
+            parseCommaList(joined);
+        } else {
+          (current.container as Record<string, unknown>)[key] = joined;
+        }
         index = cursor - 1;
       } else {
         const childIsArray = nextLine?.trimmed.startsWith("-") ?? false;
@@ -213,8 +260,13 @@ const parseToon = (input: string): unknown => {
         });
       }
     } else {
-      (current.container as Record<string, unknown>)[key] =
-        parseScalar(valuePart);
+      if (keySpec?.count) {
+        (current.container as Record<string, unknown>)[key] =
+          parseCommaList(valuePart);
+      } else {
+        (current.container as Record<string, unknown>)[key] =
+          parseScalar(valuePart);
+      }
     }
   }
 

--- a/src/app/toon-tool/page.tsx
+++ b/src/app/toon-tool/page.tsx
@@ -1,0 +1,22 @@
+import { Metadata } from "next";
+import { ToonTool } from "./ToonTool";
+
+export default function Page() {
+  return (
+    <div className="flex flex-1 items-center justify-center">
+      <div className="w-full max-w-6xl p-6 border border-neutral-700 bg-neutral-900 rounded-lg">
+        <h1 className="text-xl font-bold mb-3">TOON Formatter</h1>
+        <p className="text-sm text-neutral-400 mb-6">
+          Convert between TOON and JSON, or generate an easy-to-read TOON
+          summary.
+        </p>
+        <ToonTool />
+      </div>
+    </div>
+  );
+}
+
+export const metadata: Metadata = {
+  title: "TOON Formatter | Chris' Tools",
+  description: "Convert TOON to JSON, JSON to TOON, and generate readable TOON.",
+};


### PR DESCRIPTION
### Motivation
- Remove the top-row manual conversion buttons and make conversions reactive so editing either field updates the other automatically.
- Ensure the human-readable TOON summary is always generated and visible without extra clicks.
- Surface parse/format errors inline so users get immediate feedback while editing.

### Description
- Added `lastEdited` state and two `useEffect` hooks that parse and sync TOON→JSON when `lastEdited === "toon"` and JSON→TOON when `lastEdited === "json"`.
- Replaced manual conversion handlers and buttons with automatic sync by setting `setLastEdited("toon")` or `setLastEdited("json")` in the textareas' `onChange` handlers.
- Kept and reused the existing parsing/formatting helpers `parseToon`, `formatToon`, and `formatReadable`, and update `readableOutput` on each successful sync.
- Simplified UI copy to explain automatic behavior and show parse errors in a compact error box when parsing fails.

### Testing
- Started the dev server with `pnpm exec next dev --turbopack --hostname 0.0.0.0 --port 3000`, the app reported `Ready` and served `/toon-tool` successfully (font download warnings from Google Fonts were emitted but compilation succeeded).
- Ran an automated Playwright script that visited `http://localhost:3000/toon-tool`, populated the TOON textarea, and captured a screenshot; the script completed successfully and produced an artifact.
- The page compiled and the interactive conversion (TOON→JSON and readable summary auto-sync) exercised by the Playwright run succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69888067704883308e6095fd980195ee)